### PR TITLE
chore: unignore linting errors in building stage

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     eslint: {
-        ignoreDuringBuilds: true,
+        ignoreDuringBuilds: false,
     },
 };
 


### PR DESCRIPTION
This PR updates the Next.js configuration to enforce linting during the build process. Previously, linting errors were ignored, but this change ensures that all linting issues must be resolved before a successful build.