### PR TITLE
chore: add a new github workflow for production deployment

### DIFF
--- a/.github/workflows/gke.yml
+++ b/.github/workflows/gke.yml
@@ -1,0 +1,44 @@
+name: Build and Deploy to Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  setup-build-publish-deploy:
+    name: Setup, Build, Publish, and Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: 'Checkout'
+      uses: actions/checkout@v4
+
+    - name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v2'
+      with:
+        credentials_json: '${{ secrets.GCP_SA_KEY }}'
+
+    - name: 'Configures the Google Cloud SDK'
+      uses: google-github-actions/setup-gcloud@v1
+      with:
+        project_id: ${{ secrets.GCP_PROJECT }}
+
+    - name: 'Authenticate to Artifact Registry Docker'
+      run: |-
+        gcloud auth configure-docker '${{ vars.REGISTRY_ZONE }}-docker.pkg.dev'
+
+    - name: 'Build Docker Image'
+      run: |-
+        docker build --tag '${{ vars.REGISTRY_ZONE }}-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/${{ vars.REGISTRY_NAME }}/${{ vars.IMAGE_NAME }}:${{ github.sha }}' .
+
+    - name: 'Push Docker image'
+      run: |-
+        docker push '${{ vars.REGISTRY_ZONE }}-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/${{ vars.REGISTRY_NAME }}/${{ vars.IMAGE_NAME }}:${{ github.sha }}'
+
+    - name: 'Deploy on Cloud Run' 
+      uses: 'google-github-actions/deploy-cloudrun@v2'
+      with:
+        service: '${{ vars.DEPLOYMENT_NAME }}'
+        image: '${{ vars.REGISTRY_ZONE }}-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/${{ vars.REGISTRY_NAME }}/${{ vars.IMAGE_NAME }}:${{ github.sha }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# base
+FROM node:22-alpine AS base
+
+# deps
+FROM base AS deps
+WORKDIR /app
+
+RUN apk add --no-cache libc6-compat
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# builder
+FROM base AS builder
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+RUN npm run build
+
+# runner
+FROM base AS runner
+WORKDIR /app
+
+COPY --from=builder /app /
+
+EXPOSE 3000
+
+ENV PORT=3000
+
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
Choose Cloud Run because Cloud Run is easier to use.
