### PR TITLE
chore: deploy only when a release is published

### DIFF
--- a/.github/workflows/deploy-to-cloud-run.yml
+++ b/.github/workflows/deploy-to-cloud-run.yml
@@ -1,9 +1,8 @@
 name: Build and Deploy to Cloud Run
 
 on:
-  push:
-    tags:
-      - 'release-*'
+  release:
+    types: [published]
 
 jobs:
   setup-build-publish-deploy:
@@ -14,6 +13,8 @@ jobs:
     steps:
     - name: 'Checkout'
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.release.tag_name }}
 
     - name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v2'


### PR DESCRIPTION
Some minor fixes included:
1. check out to the tagged commit